### PR TITLE
Add ability to specify test script prelude via commandline option.

### DIFF
--- a/test-framework/dbt/src/main.rs
+++ b/test-framework/dbt/src/main.rs
@@ -1,5 +1,5 @@
 use dbt::workflow;
-use std::path::PathBuf;
+use std::{ffi::OsString, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -20,6 +20,15 @@ struct Opt {
     debuggers: Vec<PathBuf>,
 
     #[structopt(
+        short = "-p",
+        long = "--debugger-prelude",
+        parse(from_os_str),
+        help = "a string of the form <debugger-kind>:<debugger command to \
+                execute a beginning of each test script>"
+    )]
+    debugger_prelude: Vec<OsString>,
+
+    #[structopt(
         short = "-o",
         long = "--output",
         default_value = "output",
@@ -34,7 +43,7 @@ fn main() -> anyhow::Result<()> {
 
     let opt = Opt::from_args();
 
-    let debuggers = dbt::debugger::init_debuggers(&opt.debuggers)?;
+    let debuggers = dbt::debugger::init_debuggers(&opt.debuggers, &opt.debugger_prelude)?;
 
     let mut compiled_test_cases = Vec::new();
 

--- a/test-framework/dbt/src/workflow.rs
+++ b/test-framework/dbt/src/workflow.rs
@@ -96,7 +96,12 @@ pub fn run_cargo_tests(
     let mut test_results = Vec::with_capacity(test_count);
 
     println!();
-    println!("{} ({}) -- running {} tests", debugger.kind.name(), debugger.version, test_count);
+    println!(
+        "{} ({}) -- running {} tests",
+        debugger.kind.name(),
+        debugger.version,
+        test_count
+    );
     println!();
 
     for test_project_def in &test_cases.cargo_workspace.cargo_packages {


### PR DESCRIPTION
This can be used for loading debugger plugins for example.