### PR TITLE
Improve handling of test status printing.

### DIFF
--- a/plugin-tests/Cargo.toml
+++ b/plugin-tests/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 # FIXME: For some reason Cargo does not support `members = ["*"]` on Windows
-members = ["basics"]
+members = ["basics", "ignored_test"]
 exclude = ["target"]

--- a/plugin-tests/ignored_test/Cargo.toml
+++ b/plugin-tests/ignored_test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ignored_test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/plugin-tests/ignored_test/src/main.rs
+++ b/plugin-tests/ignored_test/src/main.rs
@@ -1,0 +1,9 @@
+/***
+// Unconditionally ignore this test.
+// This is a test for the #ignore-test directive.
+
+#ignore-test
+
+***/
+
+fn main() {}


### PR DESCRIPTION
Make it harder to forget printing the status for ignored tests.