### PR TITLE
Add support for selecting the Cargo profile(s) tests are built with.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
+
+* text=auto eol=lf
+*.cpp rust
+*.h rust
+*.rs rust diff=rust
+*.fixed linguist-language=Rust
+*.mir linguist-language=Rust
+src/etc/installer/gfx/* binary
+src/vendor/** -text
+Cargo.lock linguist-generated=false
+config.toml.example linguist-language=TOML
+
+# Older git versions try to fix line endings on images and fonts, this prevents it.
+*.png binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,6 +42,8 @@ jobs:
         test-framework/target/debug/dbt \
           --cargo-workspace plugin-tests \
           --debugger gdb \
+          --cargo-profile debug \
+          --cargo-profile release \
           --cargo-target-directory output/target \
           --output output
       shell: bash
@@ -53,5 +55,7 @@ jobs:
           --cargo-workspace plugin-tests `
           --debugger "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe" `
           --cargo-target-directory output\target `
+          --cargo-profile debug `
+          --cargo-profile release `
           --output output
       shell: pwsh

--- a/plugin-tests/basics/src/main.rs
+++ b/plugin-tests/basics/src/main.rs
@@ -1,5 +1,9 @@
 /***
 
+#if cargo_profile == release
+  // Local variables don't seem to show up in release builds
+  #ignore-test
+
 #if gdb
   run
   #check Breakpoint @{ .* }@ main @{ .* }@ at @{ .* }@ main.rs:
@@ -22,10 +26,10 @@
 ***/
 
 fn main() {
-  let _u32 = 123u32;
-  let _str = "I am a string";
+    let _u32 = 123u32;
+    let _str = "I am a string";
 
-  zzz(); // #break
+    zzz(); // #break
 }
 
 #[inline(never)]

--- a/plugin-tests/run-tests.sh
+++ b/plugin-tests/run-tests.sh
@@ -1,0 +1,20 @@
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OUTPUT_DIR="$SCRIPT_DIR/../output"
+
+mkdir -p "$OUTPUT_DIR/target"
+
+cd $SCRIPT_DIR/../test-framework
+cargo build
+
+cd $SCRIPT_DIR
+
+export RUST_LOG=debug
+export RUST_BACKTRACE=1
+
+../test-framework/target/debug/dbt \
+    --cargo-workspace $SCRIPT_DIR \
+    --debugger gdb \
+    --cargo-target-directory "$OUTPUT_DIR/target" \
+    --output $SCRIPT_DIR/../output \
+    --cargo-profile debug \
+    --cargo-profile release

--- a/test-framework/dbt/src/cargo_test_directory.rs
+++ b/test-framework/dbt/src/cargo_test_directory.rs
@@ -87,7 +87,7 @@ impl TestDefinition {
     }
 
     pub fn flat_name(&self) -> String {
-        self.name.replace(|c| c == '/' || c == '\\', "_")
+        self.name.replace(|c| c == '/' || c == '\\', "~")
     }
 }
 

--- a/test-framework/dbt/src/main.rs
+++ b/test-framework/dbt/src/main.rs
@@ -36,6 +36,13 @@ struct Opt {
         help = "the directory test results and debugger output will be written to"
     )]
     output_dir: PathBuf,
+
+    #[structopt(
+        long = "--cargo-profile",
+        parse(from_str),
+        help = "the Cargo profile(s) to be used for compiling test cases"
+    )]
+    cargo_profiles: Vec<String>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -51,6 +58,7 @@ fn main() -> anyhow::Result<()> {
         compiled_test_cases.push(workflow::compile_cargo_tests(
             &cargo_test_directory,
             &opt.cargo_target_directory,
+            &opt.cargo_profiles,
         )?);
     }
 

--- a/test-framework/dbt/src/test_result.rs
+++ b/test-framework/dbt/src/test_result.rs
@@ -31,6 +31,7 @@ pub struct TestResult {
     pub test_name: Arc<str>,
     pub debugger_kind: DebuggerKind,
     pub debugger_version: Arc<str>,
+    pub cargo_profile: Arc<str>,
     pub status: Status,
 }
 
@@ -38,11 +39,13 @@ impl TestResult {
     pub fn new(
         test_definition: &TestDefinition,
         debugger: &Debugger,
+        cargo_profile: &Arc<str>,
         status: Status,
     ) -> TestResult {
         TestResult {
             debugger_kind: debugger.kind,
             debugger_version: debugger.version.clone(),
+            cargo_profile: cargo_profile.clone(),
             status,
             test_name: test_definition.name.clone(),
         }

--- a/test-framework/dbt/src/workflow.rs
+++ b/test-framework/dbt/src/workflow.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{bail, Context};
+use log::debug;
 
 use crate::{
     cargo_test_directory::{CargoWorkspace, TestDefinition},
@@ -19,58 +20,87 @@ pub struct CompiledTestCases {
     /// The Cargo workspace containing all test projects
     pub cargo_workspace: Arc<CargoWorkspace>,
 
-    /// The absolute path to the directory that is expected to contain the test executables,
-    /// e.g. `cargo_target_directory.join("debug")`
-    pub executable_directory: PathBuf,
+    pub cargo_profiles: Vec<Arc<str>>,
 }
 
 pub fn compile_cargo_tests(
     cargo_test_directory: &Path,
     cargo_target_directory: &Path,
+    cargo_profiles: &Vec<String>,
 ) -> anyhow::Result<CompiledTestCases> {
-    let cargo_test_directory = Arc::new(CargoWorkspace::load(cargo_test_directory)?);
-    let cargo_target_directory = cargo_target_directory.canonicalize()?;
-    // TODO: "debug" is hardcoded
-    let executable_directory = cargo_target_directory.join("debug");
-
-    println!(
-        "Compiling cargo test packages in {}",
-        cargo_test_directory.root_path.display()
-    );
-
-    let mut cargo_command = Command::new("cargo");
-
-    cargo_command.arg("build");
-
-    cargo_command
-        .arg("--target-dir")
-        .arg(&cargo_target_directory);
-
-    cargo_command.current_dir(&cargo_test_directory.root_path);
-
-    cargo_command.env("RUSTFLAGS", "-Ccodegen-units=1");
-    cargo_command.env("RUSTFLAGS", "-Cdebuginfo=2");
-    cargo_command.env("CARGO_INCREMENTAL", "0");
-
-    let exit_status = cargo_command.status()?;
-
-    if exit_status.success() {
-        for test_project_def in &cargo_test_directory.cargo_packages {
-            for test_def in &test_project_def.test_definitions {
-                let expected_executable = executable_directory.join(&test_def.executable_name);
-                assert!(expected_executable.exists());
+    // For now just allow debug and release Cargo profiles
+    for cargo_profile in cargo_profiles {
+        match &cargo_profile[..] {
+            "debug" | "release" => {
+                // OK
+            }
+            other => {
+                bail!(
+                    "Cargo profile `{}` is not supported. Use `debug` or `release` instead.",
+                    other
+                )
             }
         }
     }
 
-    if !exit_status.success() {
-        bail!("test case compilation failed");
+    let cargo_test_directory = Arc::new(CargoWorkspace::load(cargo_test_directory)?);
+    let cargo_target_directory = cargo_target_directory.canonicalize()?;
+
+    for cargo_profile in cargo_profiles {
+        let executable_directory = cargo_target_directory.join(cargo_profile);
+
+        println!(
+            "Compiling cargo test packages in {} for Cargo profile `{}`",
+            cargo_test_directory.root_path.display(),
+            cargo_profile
+        );
+
+        let mut cargo_command = Command::new("cargo");
+
+        cargo_command.arg("build");
+
+        if cargo_profile != "debug" {
+            assert_eq!(cargo_profile, "release");
+            cargo_command.arg("--release");
+        }
+
+        cargo_command
+            .arg("--target-dir")
+            .arg(&cargo_target_directory);
+
+        cargo_command.current_dir(&cargo_test_directory.root_path);
+
+        cargo_command.env("RUSTFLAGS", "-Ccodegen-units=1");
+        cargo_command.env("RUSTFLAGS", "-Cdebuginfo=2");
+        cargo_command.env("CARGO_INCREMENTAL", "0");
+
+        debug!("Cargo command: {:?}", cargo_command);
+
+        let exit_status = cargo_command.status()?;
+
+        if exit_status.success() {
+            for test_project_def in &cargo_test_directory.cargo_packages {
+                for test_def in &test_project_def.test_definitions {
+                    let expected_executable = executable_directory.join(&test_def.executable_name);
+                    if !expected_executable.exists() {
+                        bail!(
+                            "Expected test executable at {} but it does not exist.",
+                            expected_executable.display()
+                        )
+                    }
+                }
+            }
+        }
+
+        if !exit_status.success() {
+            bail!("test case compilation failed");
+        }
     }
 
     Ok(CompiledTestCases {
         cargo_target_directory,
         cargo_workspace: cargo_test_directory,
-        executable_directory,
+        cargo_profiles: cargo_profiles.iter().map(|p| Arc::from(p.trim())).collect(),
     })
 }
 
@@ -88,29 +118,33 @@ pub fn run_cargo_tests(
 
     let mut test_results = Vec::with_capacity(test_count);
 
-    println!();
-    println!(
-        "{} ({}) -- running {} tests",
-        debugger.kind.name(),
-        debugger.version,
-        test_count
-    );
-    println!();
+    for cargo_profile in &test_cases.cargo_profiles {
+        println!();
+        println!(
+            "{} ({}) -- running {} tests for Cargo profile `{}`",
+            debugger.kind.name(),
+            debugger.version,
+            test_count,
+            cargo_profile,
+        );
+        println!();
 
-    for test_project_def in &test_cases.cargo_workspace.cargo_packages {
-        for test_definition in &test_project_def.test_definitions {
-            print!("test {} .. ", test_definition.name);
+        for test_project_def in &test_cases.cargo_workspace.cargo_packages {
+            for test_definition in &test_project_def.test_definitions {
+                print!("test {} .. ", test_definition.name);
 
-            let test_result = run_test(
-                debugger,
-                test_definition,
-                &test_cases.cargo_target_directory,
-                output_dir,
-            )?;
+                let test_result = run_test(
+                    debugger,
+                    test_definition,
+                    &test_cases.cargo_target_directory,
+                    cargo_profile,
+                    output_dir,
+                )?;
 
-            println!("{}", test_result.status.short_description());
+                println!("{}", test_result.status.short_description());
 
-            test_results.push(test_result);
+                test_results.push(test_result);
+            }
         }
     }
 
@@ -121,52 +155,80 @@ fn run_test(
     debugger: &Debugger,
     test_definition: &TestDefinition,
     cargo_target_directory: &Path,
+    cargo_profile: &Arc<str>,
     output_dir: &Path,
 ) -> anyhow::Result<TestResult> {
-    if debugger.ignore_test(test_definition) {
-        return Ok(TestResult::new(test_definition, debugger, Status::Ignored));
+    if debugger.ignore_test(test_definition, cargo_profile) {
+        return Ok(TestResult::new(
+            test_definition,
+            debugger,
+            cargo_profile,
+            Status::Ignored,
+        ));
     }
 
-    let debugger_script = generate_debugger_script(test_definition, debugger);
+    let debugger_script = generate_debugger_script(test_definition, debugger, cargo_profile);
 
     if debugger_script.is_empty() {
-        return Ok(TestResult::new(test_definition, debugger, Status::Ignored));
+        return Ok(TestResult::new(
+            test_definition,
+            debugger,
+            cargo_profile,
+            Status::Ignored,
+        ));
     }
 
-    let debugger_script_path =
-        save_debugger_script(debugger, test_definition, debugger_script, output_dir)?;
+    let debugger_script_path = save_debugger_script(
+        debugger,
+        test_definition,
+        cargo_profile,
+        debugger_script,
+        output_dir,
+    )?;
 
     let debuggee_path = cargo_target_directory
-        .join("debug")
+        .join(&cargo_profile[..])
         .join(&test_definition.executable_name);
 
     let debugger_output = debugger.run(&debugger_script_path, &debuggee_path)?;
-    process_debugger_output(debugger, test_definition, debugger_output, output_dir)
+    process_debugger_output(
+        debugger,
+        test_definition,
+        cargo_profile,
+        debugger_output,
+        output_dir,
+    )
 }
 
 fn save_debugger_script(
     debugger: &Debugger,
     test_definition: &TestDefinition,
+    cargo_profile: &Arc<str>,
     script_contents: String,
     output_dir: &Path,
 ) -> anyhow::Result<PathBuf> {
     let file_name = format!("{}-{}.dbgscript", debugger.kind.name(), debugger.version);
-    let path = output_dir_for_test(test_definition, output_dir)?.join(file_name);
+    let path = output_dir_for_test(test_definition, cargo_profile, output_dir)?.join(file_name);
     std::fs::write(&path, script_contents)?;
     Ok(path)
 }
 
-fn generate_debugger_script(test_definition: &TestDefinition, debugger: &Debugger) -> String {
-    debugger::generate_debugger_script(debugger, test_definition)
+fn generate_debugger_script(
+    test_definition: &TestDefinition,
+    debugger: &Debugger,
+    cargo_profile: &Arc<str>,
+) -> String {
+    debugger::generate_debugger_script(debugger, test_definition, cargo_profile)
 }
 
 fn process_debugger_output(
     debugger: &Debugger,
     test_definition: &TestDefinition,
+    cargo_profile: &Arc<str>,
     debugger_output: DebuggerOutput,
     output_dir: &Path,
 ) -> anyhow::Result<TestResult> {
-    let output_dir = output_dir_for_test(test_definition, output_dir)?;
+    let output_dir = output_dir_for_test(test_definition, cargo_profile, output_dir)?;
 
     std::fs::write(
         output_dir.join(format!(
@@ -189,14 +251,20 @@ fn process_debugger_output(
         debugger,
         test_definition,
         debugger_output,
+        cargo_profile,
     ))
 }
 
 fn output_dir_for_test(
     test_definition: &TestDefinition,
+    cargo_profile: &Arc<str>,
     output_dir: &Path,
 ) -> anyhow::Result<PathBuf> {
-    let path = output_dir.join(test_definition.flat_name());
+    let mut dir_name = test_definition.flat_name();
+    dir_name.push('@');
+    dir_name.push_str(&cargo_profile);
+
+    let path = output_dir.join(dir_name);
     std::fs::create_dir_all(&path).with_context(|| {
         format!(
             "while trying to create working directory for test: {}",


### PR DESCRIPTION
This PR adds the `--cargo-profile` commandline option for specifying which Cargo profiles test cases should be compiled with. Only `debug` and `release` are supported at this time. The option can be given multiple times, which will make the test runner compile and test with all given profiles. Test scripts can do profile-specific things via e.g. `#if cargo_profile == release`.