### PR TITLE
Enable parallel test execution

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Test DBT
       run: |
         cd test-framework
+        cargo clippy
         cargo test
         cargo build
       shell: bash
@@ -72,6 +73,7 @@ jobs:
     - name: Build DBT
       run: |
         cd $env:GITHUB_WORKSPACE\test-framework
+        cargo clippy
         cargo test
         cargo build
     - name: Run DBT

--- a/test-framework/dbt/Cargo.toml
+++ b/test-framework/dbt/Cargo.toml
@@ -11,8 +11,9 @@ regex = "1"
 structopt = "0.3"
 env_logger = "0.9"
 log = "0.4"
-memchr = "2.4.1"
-toml = "0.5.8"
+memchr = "2.4"
+toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 tar = "0.4"
 flate2 = { version = "1", features = ["rust_backend"] }
+rayon = "1.5"

--- a/test-framework/dbt/src/cargo_test_directory.rs
+++ b/test-framework/dbt/src/cargo_test_directory.rs
@@ -40,7 +40,7 @@ impl CargoPackage {
                 .unwrap()
                 .display()
         )
-        .replace("\\", "/")
+        .replace('\\', "/")
     }
 }
 
@@ -225,7 +225,7 @@ impl CargoWorkspace {
             }
         }
 
-        for member_not_found in members.iter().filter(|s| !s.contains("*")) {
+        for member_not_found in members.iter().filter(|s| !s.contains('*')) {
             warn!(
                 " - `{}` is listed as workspace member but the package could not be found",
                 member_not_found

--- a/test-framework/dbt/src/debugger.rs
+++ b/test-framework/dbt/src/debugger.rs
@@ -76,7 +76,7 @@ impl DebuggerKind {
             (OsString::from(env_var_name), OsString::from(env_var_value))
         }));
 
-        command.args(command_line_args.iter().map(|arg| OsString::from(arg)));
+        command.args(command_line_args.iter().map(OsString::from));
 
         match self {
             DebuggerKind::Mock => {
@@ -501,10 +501,7 @@ impl Debugger {
         let default_value: Value = "true".into();
 
         let mut evaluation_context = HashMap::new();
-        evaluation_context.insert(
-            format!("@{}", self.kind.name()).into(),
-            default_value.clone(),
-        );
+        evaluation_context.insert(format!("@{}", self.kind.name()), default_value.clone());
         evaluation_context.insert("@debugger".into(), self.kind.name().into());
         evaluation_context.insert("@version".into(), (&self.version).into());
         evaluation_context.insert("@cargo_profile".into(), cargo_profile.into());
@@ -885,7 +882,7 @@ fn partition_by_debugger_kind(
     let mut by_kind: HashMap<DebuggerKind, Vec<String>> = Default::default();
     for s in strings {
         let as_str = s.to_string_lossy();
-        if let Some((debugger, command)) = as_str.split_once(":") {
+        if let Some((debugger, command)) = as_str.split_once(':') {
             let debugger_kind = DebuggerKind::try_from(debugger.trim())?;
 
             by_kind

--- a/test-framework/dbt/src/import_export.rs
+++ b/test-framework/dbt/src/import_export.rs
@@ -93,8 +93,8 @@ fn to_tar_paths<'a>(
         crashdump_relative_path.to_path_buf(),
     ));
 
-    for file_from_target_dir in std::iter::once(crashdump.debuggee_path.as_path())
-        .chain(crashdump.extra_symbols.as_ref().map(PathBuf::as_path))
+    for file_from_target_dir in
+        std::iter::once(crashdump.debuggee_path.as_path()).chain(crashdump.extra_symbols.as_deref())
     {
         anyhow::ensure!(file_from_target_dir.file_name().is_some());
         let relative_path =

--- a/test-framework/dbt/src/main.rs
+++ b/test-framework/dbt/src/main.rs
@@ -88,6 +88,13 @@ struct Opt {
         help = "only run tests that match the given pattern"
     )]
     test_pattern: Option<String>,
+
+    #[structopt(
+        short = "-j",
+        long = "--test-threads",
+        help = "the max number tests that can run in parallel"
+    )]
+    test_threads: Option<usize>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -146,6 +153,7 @@ fn main() -> anyhow::Result<()> {
                 debugger,
                 &output_dir,
                 test_pattern.as_ref(),
+                opt.test_threads,
                 opt.verbose,
             )?;
 

--- a/test-framework/dbt/src/regex_check.rs
+++ b/test-framework/dbt/src/regex_check.rs
@@ -120,7 +120,7 @@ const PRE_I64_REGEX: &str = "@{ (i64)|(__int64) }@";
 const PRE_UNIT: &str = "@unit@";
 const PRE_UNIT_REGEX: &str = "@{ (\\(\\))|(tuple$<>) }@";
 
-fn expand_predefined_regexes<'a>(s: Cow<'a, str>) -> Cow<'a, str> {
+fn expand_predefined_regexes(s: Cow<'_, str>) -> Cow<'_, str> {
     let at_signs: Vec<usize> = memchr::memrchr_iter(b'@', s.as_bytes()).collect();
 
     if at_signs.len() < 2 {

--- a/test-framework/dbt/src/script.rs
+++ b/test-framework/dbt/src/script.rs
@@ -247,7 +247,7 @@ impl From<&Arc<str>> for Value {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CorrelationId(pub u32);
 
-#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord)]
 pub struct LineNumber(pub u32);
 
 impl LineNumber {
@@ -462,7 +462,7 @@ fn parse_line(line: &str, line_number: LineNumber) -> anyhow::Result<Line> {
         parse_phase(line)?
     } else if line.starts_with(TOKEN_GENERATE_CRASHDUMP) {
         parse_generate_crashdump(line)?
-    } else if line.starts_with("#") {
+    } else if line.starts_with('#') {
         bail!(
             "Encountered unknown keyword `{}`",
             tokenize(line).next().unwrap()

--- a/test-framework/dbt/src/workflow.rs
+++ b/test-framework/dbt/src/workflow.rs
@@ -300,9 +300,9 @@ fn run_test(
                 test_definition,
                 debugger,
                 cargo_profile,
-                Status::Errored(format!(
-                    "The test script doesn't contain any active checks for the current configuration."
-                )),
+                Status::Errored(
+                    "The test script doesn't contain any active checks for the current configuration.".to_string()
+                ),
             ),
             vec![],
         ));
@@ -539,12 +539,9 @@ fn process_debugger_output(
     );
 
     if verbose {
-        match test_result.status {
-            Status::Failed(_, ref debugger_output) => {
-                println!("debugger stdout:\n{}\n\n", &debugger_output.stdout);
-                println!("debugger stderr:\n{}\n\n", &debugger_output.stderr);
-            }
-            _ => {}
+        if let Status::Failed(_, ref debugger_output) = test_result.status {
+            println!("debugger stdout:\n{}\n\n", &debugger_output.stdout);
+            println!("debugger stderr:\n{}\n\n", &debugger_output.stderr);
         }
     }
 
@@ -558,7 +555,7 @@ fn output_dir_for_test(
 ) -> anyhow::Result<PathBuf> {
     let mut dir_name = test_definition.flat_name();
     dir_name.push('@');
-    dir_name.push_str(&cargo_profile);
+    dir_name.push_str(cargo_profile);
 
     let path = output_dir.join(dir_name);
     std::fs::create_dir_all(&path).with_context(|| {


### PR DESCRIPTION
Especially CDB seems to sometimes have long startup times, so running tests in parallel can speed things up considerably. 