### PR TITLE
Upgrade artifact actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,7 @@ jobs:
       shell: bash
 
     - name: Upload exported crashdumps
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: exported-linux-crashdumps
         path: output/exported_crashdumps.tar.gz
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Download exported Linux crashdumps
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: exported-linux-crashdumps
         path: ${{ runner.temp }}


### PR DESCRIPTION
GitHub has announced that v3 of the [actions/upload-artifact] and [actions/download-artifact] actions will be deprecated on November 30, 2024[^1]. The action has been upgraded to its most recent version to continue functioning after this date.

[actions/download-artifact]: https://github.com/actions/download-artifact
[actions/upload-artifact]: https://github.com/actions/upload-artifact
[^1]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions